### PR TITLE
Emphasize featherlight.gallery in gallery page

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -99,7 +99,7 @@
 	<body class="fl-page">
 		<div class="container">
 			<div class="jumbotron">
-				<h1>Featherlight<i>.Gallery.js</i>
+				<h1>Featherlight.Gallery<i>.js</i>
 					<br/><span> An extension for the ultra slim jQuery lightbox Featherlight.</span></h1>
 				<div class="btn-group btn-download">
 					<a class="btn btn-lg btn-info" href="https://github.com/noelboss/featherlight/">


### PR DESCRIPTION
featherlight.gallery.js is the extension being presented, so "featherlight.gallery" should be emphasized, rather than just "featherlight".
